### PR TITLE
chore: upgrade guava from 29.0 to 30.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java-version>1.7</java-version>
-		<guava-version>29.0-jre</guava-version>
+		<guava-version>30.1.1-jre</guava-version>
 		<slf4j-version>1.7.30</slf4j-version>
 		<log4j-version>2.13.3</log4j-version>
 		<junit-version>4.13.1</junit-version>


### PR DESCRIPTION
... in order to fix CVE-2020-8908.
See also: https://github.com/advisories/GHSA-5mg8-w23w-74h3